### PR TITLE
use port passed as argument rather than env variable

### DIFF
--- a/lib/apps.js
+++ b/lib/apps.js
@@ -26,7 +26,7 @@ module.exports = {
             }
         );
 
-        controller.setupWebserver(process.env.PORT,function(err,webserver) {
+        controller.setupWebserver(port,function(err,webserver) {
             controller.createWebhookEndpoints(controller.webserver);
 
             controller.createOauthEndpoints(controller.webserver,function(err,req,res) {


### PR DESCRIPTION
The setupWebserver function was being passed the port number from the environment variable, rather than the `port` argument from the calling function.