### PR TITLE
Updated app start error to output the expected var names when not specified

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Don Goodman-Wilson
+Original work Copyright (c) 2016 Don Goodman-Wilson
+Modified work Copyright (c) 2018 Fisharply, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # aftership-bot
 
+Receives input from slack channel(s) by listening for a `!track <TrackingID> <Description>` command. On success, aftership-bot will respond in the channel stating either success or specifying the error details.
+
+There's still tons of room for improvement and expansion, so pull requests are welcomed!
+
 ## The story of the aftership-bot
 
 A (not so) long time ago, a suburbun couple was receiving and sending so many packages for their small business that they wanted a way to track them. They stumbled upon aftership.com, which helped them track all of their packages in one place. What they didn't want was another website to go to and interact with as part of their workflow.

--- a/README.md
+++ b/README.md
@@ -1,60 +1,26 @@
-# easy-peasy-bot
+# aftership-bot
 
-## The story of a (Slack)bot
+## The story of the aftership-bot
 
-A (not so) long time ago, a team called Tiny Speck built an app to communicate with each other as they worked.
-In their daily work, they found that there were some mindless tasks they had to do over and over. These things pulled them out of important conversations, which slowed them down.
+A (not so) long time ago, a suburbun couple was receiving and sending so many packages for their small business that they wanted a way to track them. They stumbled upon aftership.com, which helped them track all of their packages in one place. What they didn't want was another website to go to and interact with as part of their workflow.
+In their daily work, they found that it would be best to have a home base for managing the business. As they were already using Slack to communicate casually, they found that there would be great benefit if they could just enter their package tracking information and descriptions into their slack channels and be done with it. They set up a MagicMirror to display the shipment data from aftership.com and created this here bot to quickly add package details to the aftership.com backend.
+Using this repository, you too can simplify your package tracking efforts.
 
-So, they built a special user in their messaging app: not a human user, but a digital user. The digital user took on some of their mindless tasks and integrated the other apps they used into their conversations.
+# Using aftership-bot
 
-Eventually their app was named Slack and their digital user, Slackbot.
-And lo, you can build a Slack Bot, too! With our API and this nifty repository, a bot for your team can be all yours.
-
-# Using Botkit for Custom Bots
 1. Fork this project.
 2. Open up your favorite terminal app, and clone your new repository to your local computer.
 3. This is a Node.js project, so you’ll need to install the various dependencies by running:
-    npm install
-4. Edit `package.json` to give your bot a name and update the GitHub URLs to reflect the location of your fork in GitHub.
+   npm install
+4. Edit `package.json` to update the GitHub URLs to reflect the location of your fork in GitHub.
 5. Go to https://my.slack.com/apps/new/A0F7YS25R-bots and pick a name for your new bot.
 6. Once you’ve clicked “Add integration,” you’ll be taken to a page where you can further customize your bot. Of importance is the bot token—take note of it now.
 7. Once you have the token, you can run your bot easily:
 
-    ```bash
-    TOKEN=xoxb-your-token-here npm start
-    ```
+   ```bash
+   AFTERSHIP_KEY= abc-def CLIENT_ID=xxx.yyy CLIENT_SECRET=qrst-uvw PORT=8765 npm start
+   ```
 
-    Your bot will now attempt to log into your team, and you should be able talk to it. Try telling your new bot “hello”. It should say “Hello!” back!
+   Your bot will now attempt to log into your team, and you should be able talk to it. Try telling your new bot “hello”. It should say “Hello!” back!
 
-8. Botkit is structured around event listeners. The most important is the “hear” listener, which kicks off an action when your bot hears something. `index.js` contains the core logic, and has this event listener:
-
-    ```javascript
-    controller.hears('hello','direct_message', function(bot,message) {
-        bot.reply(message, 'Hello!');
-    });
-    ```
-
-    This event handler is triggered when the bot receives a direct message from a user that contains the word “hello.”
-
-    The bot responds in the direct message with, “Hello!”
-
-9. You can listen to any kind of message or you can configure your bot to only listen to direct messages or specific @-mentions of your bot. It’s up to you! To start let’s re-write the event listener to be more  flexible about the greetings it is listening for:
-    ```javascript
-    controller.hears(['hello', 'hi', 'greetings'], ['direct_mention', 'mention', 'direct_message'], function(bot,message) {
-         bot.reply(message, 'Hello!');
-     });
-    ```
-
-    Now our bot will respond any time it sees “hello,” “hi,” or “greetings” in either a DM or a message that @-mentions the bot. (Don’t forget to restart your bot after each edit!)
-
-## Hurrah! Welcome to Level 2
-
-You’ve built your first bot in Slack, and it’s not just a Hello World bot—it’s a Hi World and Greetings World bot too!
-
-At this point you will probably want to start doing more sophisticated things, like making requests to external services, so your bot can respond with timely and useful information (depending on what your bot does, of course). There’s a lot more to Botkit than this! You can learn more about Botkit’s awesome features by simply perusing the [Botkit documentation](http://howdy.ai/botkit/docs/).
-
-Once you’ve got your bot developed to your liking, it is ready to be deployed to your own hosting framework. No other configuration is necessary, except storing the token and desired port in environment variables.
-
-# Using Botkit for Bot Apps
-
-You can find full instructions for building a bot app with this repository at https://medium.com/slack-developer-blog/easy-peasy-bots-getting-started-96b65e6049bf#.4ay2fjf32
+   Next, follow your bot's instructions to invite it to a channel. It'll listen within this channel for any !track `TrackingNumber` `description` commands and add the specified package to Aftership.

--- a/bot.yml
+++ b/bot.yml
@@ -1,3 +1,3 @@
-name: Easy Peasy Bot
-description: A simple node.js bot
+name: Aftership Bot
+description: A simple node.js Slack bot for adding packages to Aftership
 avatar: avatar.png

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
  * A Bot for Slack!
  */
 
+const Aftership = require('aftership')(process.env.AFTERSHIP_KEY);
 
 /**
  * Define a function for initiating a conversation on installation
@@ -14,13 +15,12 @@ function onInstallation(bot, installer) {
             if (err) {
                 console.log(err);
             } else {
-                convo.say('I am a bot that has just joined your team');
+                convo.say('Hello. I am your aftership bot that has just joined your team.');
                 convo.say('You must now /invite me to a channel so that I can be of use!');
             }
         });
     }
 }
-
 
 /**
  * Configure the persistence options
@@ -47,12 +47,12 @@ if (process.env.TOKEN || process.env.SLACK_TOKEN) {
     var customIntegration = require('./lib/custom_integrations');
     var token = (process.env.TOKEN) ? process.env.TOKEN : process.env.SLACK_TOKEN;
     var controller = customIntegration.configure(token, config, onInstallation);
-} else if (process.env.CLIENT_ID && process.env.CLIENT_SECRET && process.env.PORT) {
+} else if (process.env.CLIENT_ID && process.env.CLIENT_SECRET && process.env.PORT && process.env.AFTERSHIP_KEY) {
     //Treat this as an app
     var app = require('./lib/apps');
     var controller = app.configure(process.env.PORT, process.env.CLIENT_ID, process.env.CLIENT_SECRET, config, onInstallation);
 } else {
-    console.log('Error: If this is a custom integration, please specify TOKEN in the environment. If this is an app, please specify CLIENTID, CLIENTSECRET, and PORT in the environment');
+    console.log('Error: If this is a custom integration, please specify TOKEN in the environment. If this is an app, please specify CLIENT_ID, CLIENT_SECRET, AFTERSHIP_KEY, and PORT in the environment');
     process.exit(1);
 }
 
@@ -77,32 +77,37 @@ controller.on('rtm_close', function (bot) {
 
 
 /**
- * Core bot logic goes here!
+ * Core bot logic follows
  */
-// BEGIN EDITING HERE!
 
 controller.on('bot_channel_join', function (bot, message) {
-    bot.reply(message, "I'm here!")
+    bot.reply(message, "I'm here and I'm ready to start helping you track your packages!");
+    bot.reply(message, "Simply use !track TRACKING-ID-NUMBER and a description of the package.");
+    bot.reply(message, "I'll add that package to your Aftership list of tracked packages.");
 });
 
-controller.hears('hello', 'direct_message', function (bot, message) {
-    bot.reply(message, 'Hello!');
+controller.hears('(^)!track', 'ambient', function (bot, message) {
+    var arr = message.text.split(' ');
+    var params = arr.splice(0,2);
+    params.push(arr.join(' '));
+    
+    var trackId = params[1];
+    var description = params[2];
+
+    let body = {
+        'tracking': {
+            'tracking_number': trackId,
+            'title': description
+                }
+    };
+    Aftership.call('POST', '/trackings', {
+        body: body
+    }, function (err, response) {
+        if (err) {
+            console.log(err);
+            bot.reply(message, 'Error ' + err.code + ': ' +err.message);            
+        }else {
+            bot.reply(message, 'Successfully added tracking for ' + description + ' (' + trackId + ')');
+        }
+    });
 });
-
-
-/**
- * AN example of what could be:
- * Any un-handled direct mention gets a reaction and a pat response!
- */
-//controller.on('direct_message,mention,direct_mention', function (bot, message) {
-//    bot.api.reactions.add({
-//        timestamp: message.ts,
-//        channel: message.channel,
-//        name: 'robot_face',
-//    }, function (err) {
-//        if (err) {
-//            console.log(err)
-//        }
-//        bot.reply(message, 'I heard you loud and clear boss.');
-//    });
-//});

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * A Bot for Slack!
  */
 
-const Aftership = require('aftership')(process.env.AFTERSHIP_KEY);
+const Aftership = require("aftership")(process.env.AFTERSHIP_KEY);
 
 /**
  * Define a function for initiating a conversation on installation
@@ -10,16 +10,20 @@ const Aftership = require('aftership')(process.env.AFTERSHIP_KEY);
  */
 
 function onInstallation(bot, installer) {
-    if (installer) {
-        bot.startPrivateConversation({user: installer}, function (err, convo) {
-            if (err) {
-                console.log(err);
-            } else {
-                convo.say('Hello. I am your aftership bot that has just joined your team.');
-                convo.say('You must now /invite me to a channel so that I can be of use!');
-            }
-        });
-    }
+  if (installer) {
+    bot.startPrivateConversation({ user: installer }, function(err, convo) {
+      if (err) {
+        console.log(err);
+      } else {
+        convo.say(
+          "Hello. I am your aftership bot that has just joined your team."
+        );
+        convo.say(
+          "You must now /invite me to a channel so that I can be of use!"
+        );
+      }
+    });
+  }
 }
 
 /**
@@ -28,14 +32,16 @@ function onInstallation(bot, installer) {
 
 var config = {};
 if (process.env.MONGOLAB_URI) {
-    var BotkitStorage = require('botkit-storage-mongo');
-    config = {
-        storage: BotkitStorage({mongoUri: process.env.MONGOLAB_URI}),
-    };
+  var BotkitStorage = require("botkit-storage-mongo");
+  config = {
+    storage: BotkitStorage({ mongoUri: process.env.MONGOLAB_URI })
+  };
 } else {
-    config = {
-        json_file_store: ((process.env.TOKEN)?'./db_slack_bot_ci/':'./db_slack_bot_a/'), //use a different name if an app or CI
-    };
+  config = {
+    json_file_store: process.env.TOKEN
+      ? "./db_slack_bot_ci/"
+      : "./db_slack_bot_a/" //use a different name if an app or CI
+  };
 }
 
 /**
@@ -43,19 +49,31 @@ if (process.env.MONGOLAB_URI) {
  */
 
 if (process.env.TOKEN || process.env.SLACK_TOKEN) {
-    //Treat this as a custom integration
-    var customIntegration = require('./lib/custom_integrations');
-    var token = (process.env.TOKEN) ? process.env.TOKEN : process.env.SLACK_TOKEN;
-    var controller = customIntegration.configure(token, config, onInstallation);
-} else if (process.env.CLIENT_ID && process.env.CLIENT_SECRET && process.env.PORT && process.env.AFTERSHIP_KEY) {
-    //Treat this as an app
-    var app = require('./lib/apps');
-    var controller = app.configure(process.env.PORT, process.env.CLIENT_ID, process.env.CLIENT_SECRET, config, onInstallation);
+  //Treat this as a custom integration
+  var customIntegration = require("./lib/custom_integrations");
+  var token = process.env.TOKEN ? process.env.TOKEN : process.env.SLACK_TOKEN;
+  var controller = customIntegration.configure(token, config, onInstallation);
+} else if (
+  process.env.CLIENT_ID &&
+  process.env.CLIENT_SECRET &&
+  process.env.PORT &&
+  process.env.AFTERSHIP_KEY
+) {
+  //Treat this as an app
+  var app = require("./lib/apps");
+  var controller = app.configure(
+    process.env.PORT,
+    process.env.CLIENT_ID,
+    process.env.CLIENT_SECRET,
+    config,
+    onInstallation
+  );
 } else {
-    console.log('Error: If this is a custom integration, please specify TOKEN in the environment. If this is an app, please specify CLIENT_ID, CLIENT_SECRET, AFTERSHIP_KEY, and PORT in the environment');
-    process.exit(1);
+  console.log(
+    "Error: If this is a custom integration, please specify TOKEN in the environment. If this is an app, please specify CLIENT_ID, CLIENT_SECRET, AFTERSHIP_KEY, and PORT in the environment"
+  );
+  process.exit(1);
 }
-
 
 /**
  * A demonstration for how to handle websocket events. In this case, just log when we have and have not
@@ -66,48 +84,72 @@ if (process.env.TOKEN || process.env.SLACK_TOKEN) {
  * TODO: fixed b0rked reconnect behavior
  */
 // Handle events related to the websocket connection to Slack
-controller.on('rtm_open', function (bot) {
-    console.log('** The RTM api just connected!');
+controller.on("rtm_open", function(bot) {
+  console.log("** The RTM api just connected!");
 });
 
-controller.on('rtm_close', function (bot) {
-    console.log('** The RTM api just closed');
-    // you may want to attempt to re-open
+controller.on("rtm_close", function(bot) {
+  console.log("** The RTM api just closed");
+  // you may want to attempt to re-open
 });
-
 
 /**
  * Core bot logic follows
  */
 
-controller.on('bot_channel_join', function (bot, message) {
-    bot.reply(message, "I'm here and I'm ready to start helping you track your packages!");
-    bot.reply(message, "Simply use !track TRACKING-ID-NUMBER and a description of the package.");
-    bot.reply(message, "I'll add that package to your Aftership list of tracked packages.");
+controller.on("bot_channel_join", function(bot, message) {
+  bot.reply(
+    message,
+    "I'm here and I'm ready to start helping you track your packages!"
+  );
+  bot.reply(
+    message,
+    "Simply use !track TRACKING-ID-NUMBER and a description of the package."
+  );
+  bot.reply(
+    message,
+    "I'll add that package to your Aftership list of tracked packages."
+  );
 });
 
-controller.hears('(^)!track', 'ambient', function (bot, message) {
-    var arr = message.text.split(' ');
-    var params = arr.splice(0,2);
-    params.push(arr.join(' '));
-    
-    var trackId = params[1];
-    var description = params[2];
+controller.hears("(^)!track", "ambient", function(bot, message) {
+  var arr = message.text.split(" ");
+  var params = arr.splice(0, 2);
+  params.push(arr.join(" "));
 
-    let body = {
-        'tracking': {
-            'tracking_number': trackId,
-            'title': description
-                }
-    };
-    Aftership.call('POST', '/trackings', {
-        body: body
-    }, function (err, response) {
-        if (err) {
-            console.log(err);
-            bot.reply(message, 'Error ' + err.code + ': ' +err.message);            
-        }else {
-            bot.reply(message, 'Successfully added tracking for ' + description + ' (' + trackId + ')');
-        }
-    });
+  var trackId = params[1];
+  var description = params[2];
+
+  let body = {
+    tracking: {
+      tracking_number: trackId,
+      title: description
+    }
+  };
+  Aftership.call(
+    "POST",
+    "/trackings",
+    {
+      body: body
+    },
+    function(err, response) {
+      if (err) {
+        console.log(err);
+        bot.reply(message, "Error " + err.code + ": " + err.message);
+      } else {
+        bot.reply(
+          message,
+          "Successfully added tracking for " +
+            description +
+            " (" +
+            trackId +
+            ")"
+        );
+      }
+    }
+  );
+});
+
+controller.hears("hello", "direct_message", function(bot, message) {
+  bot.reply(message, "Hello!");
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "easy-peasy-bot",
+  "name": "aftership-bot",
   "version": "1.0.0",
-  "description": "The awesomest bot evar.",
+  "description": "Slack bot for adding packages to an aftership account.",
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
@@ -9,23 +9,36 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DEGoodmanWilson/easy-peasy-bot-app.git"
+    "url": "git+https://github.com/jfisher446/aftership-bot.git"
   },
   "keywords": [
     "slack",
-    "bot"
+    "bot",
+    "package",
+    "tracking",
+    "aftership",
+    "after",
+    "ship",
+    "UPS",
+    "Fedex",
+    "USPS",
+    "shipment",
+    "shipping",
+    "tracker", 
+    "courier"
   ],
-  "author": "D.E. Goodman-Wilson",
+  "author": "John Fisher, Fisharply, LLC",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/DEGoodmanWilson/easy-peasy-bot-app/issues"
+    "url": "https://github.com/jfisher446/aftership-bot/issues"
   },
-  "homepage": "https://github.com/DEGoodmanWilson/easy-peasy-bot-app#readme",
+  "homepage": "https://github.com/jfisher446/aftership-bot#readme",
   "engines": {
-    "node": "5.1.1"
+    "node": "8.12.0"
   },
   "dependencies": {
-    "botkit": "0.2.2",
+    "aftership": "^5.4.4",
+    "botkit": "^0.6.20",
     "botkit-storage-mongo": "^1.0.2",
     "mongodb": "^1.4.39"
   }


### PR DESCRIPTION
Previously, the message would output advising the need for specification of TOKEN, CLIENTSECRET, and CLIENTID. This change modifies the requests messaging to state the actual names (with underscores) for the secret and ID variables.