### PR TITLE
Fix env vars warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,13 @@ if (process.env.TOKEN || process.env.SLACK_TOKEN) {
     var controller = app.configure(process.env.PORT, process.env.CLIENT_ID, process.env.CLIENT_SECRET, config, onInstallation);
 } else {
     console.log('Error: If this is a custom integration, please specify TOKEN or SLACK_TOKEN in the environment. If this is an app, please specify CLIENT_ID, CLIENT_SECRET, and PORT in the environment');
+    console.log('Current ENVs:\n' +
+    '  TOKEN: ' + process.env.TOKEN + '\n' +
+    '  SLACK_TOKEN: ' + process.env.SLACK_TOKEN + '\n' +
+    '  CLIENT_ID: ' + process.env.CLIENT_ID + '\n' +
+    '  CLIENT_SECRET: ' + process.env.CLIENT_SECRET + '\n' +
+    '  PORT: ' + process.env.PORT
+    )
     process.exit(1);
 }
 

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ if (process.env.TOKEN || process.env.SLACK_TOKEN) {
     var app = require('./lib/apps');
     var controller = app.configure(process.env.PORT, process.env.CLIENT_ID, process.env.CLIENT_SECRET, config, onInstallation);
 } else {
-    console.log('Error: If this is a custom integration, please specify TOKEN in the environment. If this is an app, please specify CLIENTID, CLIENTSECRET, and PORT in the environment');
+    console.log('Error: If this is a custom integration, please specify TOKEN or SLACK_TOKEN in the environment. If this is an app, please specify CLIENT_ID, CLIENT_SECRET, and PORT in the environment');
     process.exit(1);
 }
 


### PR DESCRIPTION
The warning message displays incongruent env vars (eg. its saying you should specify `CLIENTID` when you should actually be providing `CLIENT_ID`), which may trip people up (me being one of them). While at it, it seemed like a good idea to display to the user what the current env vars are for a better debugging experience. 